### PR TITLE
Add distinct headings for talks and writing feeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ I am **Ladislav Prskavec**, a Software Engineer and SRE based in Prague
 [![Blog in Czech][web-image-2]](https://blog.prskavec.net/)
 [![Twitter Follow][twitter-image]](https://twitter.com/abtris)
 
-I'm running [Go meetup Prague](https://www.gomeetupprague.cz/), if you are interested in Go and you are located near Prague join our meetup group.
+I'm running [Go meetup Prague](https://www.gomeetupprague.cz/), so if you are interested in Go and located near Prague, join our meetup group.
 
-> *I’m really passionate about site reliability engineering. I think the biggest problem for current companies is doesn't have SRE engineers if they need it. I’m helping to find solutions for my company and others who can listen*
+> *I’m really passionate about site reliability engineering. I think the biggest problem for companies today is that they don’t have the SRE engineers they need. I’m helping to find solutions for my company and for others who want to listen.*
 
 
 
@@ -26,7 +26,7 @@ I'm running [Go meetup Prague](https://www.gomeetupprague.cz/), if you are inter
 
 
 
-### Posts on Prskavec.Net in en
+### ✍️ Writing
 - [How I Use Logseq as a Personal Knowledge Base](https://www.prskavec.net/post/how-i-use-logseq-as-a-personal-knowledge-base/)
 - [Agent Harnesses: Why You Shouldn't Bet Your Company on Claude Code or Codex](https://www.prskavec.net/post/agent-harnesses/)
 - [Schema-First Telemetry in Go: A New Approach to Observability](https://www.prskavec.net/post/schema_first_telemetry/)
@@ -40,7 +40,7 @@ I'm running [Go meetup Prague](https://www.gomeetupprague.cz/), if you are inter
 
 
 
-### Talks on Prskavec.Net in en
+### 🎤 Talks
 - [How to Make an MCP Server in Go](https://www.prskavec.net/talk/2026-06-12-techspresso/)
 - [Under the Hood of AI: Building Your Own MCP Server in Go](https://www.prskavec.net/talk/2026-05-27-webexpo/)
 - [From Small Terraform Projects to Terralith](https://www.prskavec.net/talk/2025-04-23-cloudnative/)

--- a/README.md.template
+++ b/README.md.template
@@ -12,7 +12,7 @@ I'm running [Go meetup Prague](https://www.gomeetupprague.cz/), so if you are in
 
 {{range .}}
 
-### {{.Title}} in {{.Language}}
+{{if contains .Url "/talk/"}}### 🎤 Talks{{else if contains .Url "/post/"}}### ✍️ Writing{{else}}### {{.Title}} in {{.Language}}{{end}}
 {{range .Items}}- {{.}}{{end}}
 {{end}}
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -119,12 +120,17 @@ func main() {
 		data = append(data, blog)
 	}
 
-	t, err := template.New("readme").Parse(text)
-	if err != nil {
+	if err := render(os.Stdout, text, data); err != nil {
 		log.Fatal(err)
 	}
-	err = t.Execute(os.Stdout, data)
+}
+
+func render(w io.Writer, tmpl string, data []Blog) error {
+	t, err := template.New("readme").Funcs(template.FuncMap{
+		"contains": strings.Contains,
+	}).Parse(tmpl)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+	return t.Execute(w, data)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestRenderHeadings runs the real README.md.template through render and
+// verifies each feed gets the right section heading: writing and talks get
+// their custom labels (matched on the feed URL), everything else falls back
+// to "<Title> in <Language>".
+func TestRenderHeadings(t *testing.T) {
+	tmpl, err := os.ReadFile("README.md.template")
+	if err != nil {
+		t.Fatalf("reading template: %v", err)
+	}
+
+	data := []Blog{
+		{Title: "Prskavčí blog", Url: "https://blog.prskavec.net/index.xml", Language: "cs-CZ", Items: []string{"[cs post](https://blog.prskavec.net/a)\n"}},
+		{Title: "Posts on Prskavec.Net", Url: "https://www.prskavec.net/post/index.xml", Language: "en", Items: []string{"[a post](https://www.prskavec.net/post/a)\n"}},
+		{Title: "Talks on Prskavec.Net", Url: "https://www.prskavec.net/talk/index.xml", Language: "en", Items: []string{"[a talk](https://www.prskavec.net/talk/a)\n"}},
+	}
+
+	var buf strings.Builder
+	if err := render(&buf, string(tmpl), data); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := buf.String()
+
+	want := []string{
+		"### ✍️ Writing",
+		"### 🎤 Talks",
+		"### Prskavčí blog in cs-CZ",
+		"- [a post](https://www.prskavec.net/post/a)",
+		"- [a talk](https://www.prskavec.net/talk/a)",
+	}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("rendered output missing %q\n--- output ---\n%s", w, out)
+		}
+	}
+
+	// The generic label must not leak onto the writing/talks feeds.
+	for _, bad := range []string{"### Posts on Prskavec.Net in en", "### Talks on Prskavec.Net in en"} {
+		if strings.Contains(out, bad) {
+			t.Errorf("rendered output should not contain generic heading %q", bad)
+		}
+	}
+}
+
+func TestParseLimits(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		n    int
+		want []int
+	}{
+		{"empty defaults", "", 3, []int{defaultLimit, defaultLimit, defaultLimit}},
+		{"all set", "5,2,7", 3, []int{5, 2, 7}},
+		{"partial fills rest with default", "5", 3, []int{5, defaultLimit, defaultLimit}},
+		{"whitespace trimmed", " 5 , 2 ", 2, []int{5, 2}},
+		{"invalid keeps default", "5,x,3", 3, []int{5, defaultLimit, 3}},
+		{"non-positive keeps default", "5,0,-1", 3, []int{5, defaultLimit, defaultLimit}},
+		{"extra parts ignored", "5,2,7,9", 2, []int{5, 2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseLimits(tt.raw, tt.n)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseLimits(%q, %d) = %v, want %v", tt.raw, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetFirst(t *testing.T) {
+	in := []string{"a", "b", "c"}
+	if got := getFirst(in, 2); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Errorf("getFirst limit<len = %v, want [a b]", got)
+	}
+	if got := getFirst(in, 5); !reflect.DeepEqual(got, in) {
+		t.Errorf("getFirst limit>len = %v, want %v", got, in)
+	}
+}


### PR DESCRIPTION
## What

The site now exposes two dedicated feeds — writing (`/post/index.xml`) and talks (`/talk/index.xml`). This gives each its own section heading in the generated README instead of the awkward channel-title default.

- `/talk/` feeds render as `### 🎤 Talks`
- `/post/` feeds render as `### ✍️ Writing`
- Any other feed (e.g. the Czech `blog.prskavec.net`) keeps the existing `### <Title> in <Language>` format

The matching is done on the feed URL via a small `contains` template function. No change was needed to support N feeds — the `BLOG_URLS` secret already drives that.

## How

- Added a `contains` func to the template's `FuncMap` and URL-based conditionals in `README.md.template`.
- Extracted `render()` from `main()` so the template logic is testable against the real template file.

## Tests

`main_test.go`:

- **TestRenderHeadings** — runs the actual `README.md.template` through `render()` with sample writing/talks/cs-blog data and asserts the correct headings appear (and the generic heading does not leak onto the writing/talks feeds).
- **TestParseLimits** — table-driven coverage of defaults, partial input, whitespace, invalid, non-positive, and extra parts.
- **TestGetFirst** — truncation vs. pass-through.

All green: `go test ./...` passes.

Note: the `BLOG_URLS` secret has already been updated to include the two new feeds.
