### PR TITLE
Update bio to match prskavec.net and add YBYR podcast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build README
 
 on:
   push:
+    branches:
+      - master
   workflow_dispatch:
   schedule:
     - cron: "0 4 * * *"

--- a/README.md.template
+++ b/README.md.template
@@ -1,14 +1,15 @@
 ### Hi there 👋
 
-I am **Ladislav Prskavec**, a Software Engineer and SRE based in Prague
+I am **Ladislav Prskavec** — a software engineer and SRE focused on the small operational habits that keep production systems quiet: on-call hygiene, observability, and writing infrastructure that doesn't surprise you at 3am.
 
 [![Homepage][web-image]](https://www.prskavec.net/)
-[![Blog in Czech][web-image-2]](https://blog.prskavec.net/)
-[![Twitter Follow][twitter-image]](https://twitter.com/abtris)
+[![X Follow][twitter-image]](https://x.com/abtris)
 
 I'm running [Go meetup Prague](https://www.gomeetupprague.cz/), so if you are interested in Go and located near Prague, join our meetup group.
 
-> *I’m really passionate about site reliability engineering. I think the biggest problem for companies today is that they don’t have the SRE engineers they need. I’m helping to find solutions for my company and for others who want to listen.*
+I co-host [You Build It, You Run It](https://ybyr.net/podcast) — a podcast on operating software in production: the discipline, the failure modes, and the people behind the on-call rotation.
+
+> *Software reliability, distributed systems, and one Go meetup.*
 
 {{range .}}
 


### PR DESCRIPTION
Refreshes the static about-me section using current content from www.prskavec.net.

- Intro now matches the site's one-liner (on-call hygiene, observability, infra that doesn't surprise you at 3am)
- Adds the You Build It, You Run It podcast (ybyr.net/podcast)
- Updates the quote to the site's current tagline
- Syncs README.md badges to the template (X badge; drops stale Czech-blog + Twitter badges)

Feed sections (Blog / Writing / Talks) are untouched — CI regenerates them from BLOG_URLS on push.